### PR TITLE
Inject ReminderDataSource

### DIFF
--- a/starter/app/src/main/java/com/udacity/project4/locationreminders/geofence/GeofenceTransitionsJobIntentService.kt
+++ b/starter/app/src/main/java/com/udacity/project4/locationreminders/geofence/GeofenceTransitionsJobIntentService.kt
@@ -43,7 +43,7 @@ class GeofenceTransitionsJobIntentService : JobIntentService(), CoroutineScope {
         val requestId = ""
 
         //Get the local repository instance
-        val remindersLocalRepository: RemindersLocalRepository by inject()
+        val remindersLocalRepository: ReminderDataSource by inject()
 //        Interaction to the repository has to be through a coroutine scope
         CoroutineScope(coroutineContext).launch(SupervisorJob()) {
             //get the reminder with the request id


### PR DESCRIPTION
In the **GeofenceTransitionsJobIntentService.kt**  the _sendNotification()_ injecting _RemindersLocalRepository_ the following way:
```
 private fun sendNotification(triggeringGeofences: List<Geofence>) {
      ...
        //Get the local repository instance
        val remindersLocalRepository: RemindersLocalRepository by inject()
      ...
  }
```
This caused the following error message: 
`org.koin.core.error.NoBeanDefFoundException: No definition found for 'com.udacity.project4.locationreminders.data.local.RemindersLocalRepository' has been found. Check your module definitions.`

Since in the **MyApp.kt** module definition contains:

`single { RemindersLocalRepository(get()) as ReminderDataSource}`

The _RemindersLocalRepository_ should be injected by _ReminderDataSource_ interface.
